### PR TITLE
load arviz object with from_cmdstan rather than from_cmdstanpy

### DIFF
--- a/{{cookiecutter.repo_name}}/src/sampling.py
+++ b/{{cookiecutter.repo_name}}/src/sampling.py
@@ -32,12 +32,12 @@ def sample(
         stan_input = json.load(f)
     coords["ix_train"] = [i - 1 for i in stan_input["ix_train"]]
     coords["ix_test"] = [i - 1 for i in stan_input["ix_test"]]
-    mcmc = model.sample(data=stan_input, **sample_kwargs)
-    return az.from_cmdstanpy(
-        posterior=mcmc,
+    mcmc = model.sample(data=input_json, **sample_kwargs)
+    return az.from_cmdstan(
+        posterior=mcmc.runset.csv_files,
         log_likelihood="llik",
         posterior_predictive="yrep",
-        observed_data=stan_input,
+        observed_data=input_json,
         coords=coords,
         dims=dims,
     )


### PR DESCRIPTION
This is because `from_cmdstanpy` sometimes breaks due to variable shape problems.


Checklist:

- [x] `requirements.txt` up to date
- [x] No pytest errors
- [x] `make analysis` works
- [x] `README.md` up to date
- [x] docs up to date
- [x] `{{cookiecutter.repo_name}}/README.md` up to date
- [x] `investigate.ipynb` up to date
